### PR TITLE
Added new constructors to handlers to allow mocking FMS client.

### DIFF
--- a/aws-fms-notificationchannel/src/main/java/software/amazon/fms/notificationchannel/CreateHandler.java
+++ b/aws-fms-notificationchannel/src/main/java/software/amazon/fms/notificationchannel/CreateHandler.java
@@ -1,5 +1,6 @@
 package software.amazon.fms.notificationchannel;
 
+import software.amazon.awssdk.services.fms.FmsClient;
 import software.amazon.awssdk.services.fms.model.GetNotificationChannelResponse;
 import software.amazon.awssdk.services.fms.model.PutNotificationChannelRequest;
 import software.amazon.awssdk.services.fms.model.PutNotificationChannelResponse;
@@ -7,6 +8,14 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 
 public class CreateHandler extends NotificationChannelHandler {
+
+    CreateHandler() {
+        super();
+    }
+
+    CreateHandler(final FmsClient client) {
+        super(client);
+    }
 
     @Override
     protected boolean throwAlreadyExistsException() {

--- a/aws-fms-notificationchannel/src/main/java/software/amazon/fms/notificationchannel/DeleteHandler.java
+++ b/aws-fms-notificationchannel/src/main/java/software/amazon/fms/notificationchannel/DeleteHandler.java
@@ -1,5 +1,6 @@
 package software.amazon.fms.notificationchannel;
 
+import software.amazon.awssdk.services.fms.FmsClient;
 import software.amazon.awssdk.services.fms.model.DeleteNotificationChannelRequest;
 import software.amazon.awssdk.services.fms.model.DeleteNotificationChannelResponse;
 import software.amazon.awssdk.services.fms.model.GetNotificationChannelResponse;
@@ -7,6 +8,14 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 
 public class DeleteHandler extends NotificationChannelHandler {
+
+    DeleteHandler() {
+        super();
+    }
+
+    DeleteHandler(final FmsClient client) {
+        super(client);
+    }
 
     @Override
     protected boolean throwNotFoundException() {

--- a/aws-fms-notificationchannel/src/main/java/software/amazon/fms/notificationchannel/NotificationChannelHandler.java
+++ b/aws-fms-notificationchannel/src/main/java/software/amazon/fms/notificationchannel/NotificationChannelHandler.java
@@ -22,9 +22,18 @@ abstract class NotificationChannelHandler extends BaseHandler<CallbackContext> {
     /** Standard read request to check pre-action resource state. */
     private final GetNotificationChannelRequest getNotificationChannelRequest;
 
-    /** Constructor. */
+    /** Constructor for use by CloudFormation, uses default FMS client. */
     NotificationChannelHandler() {
         client = FmsClient.create();
+        getNotificationChannelRequest = GetNotificationChannelRequest.builder().build();
+    }
+
+    /**
+     * Constructor for use in tests, allows for a mocked client.
+     * @param client The FmsClient to use.
+     */
+    NotificationChannelHandler(final FmsClient client) {
+        this.client = client;
         getNotificationChannelRequest = GetNotificationChannelRequest.builder().build();
     }
 

--- a/aws-fms-notificationchannel/src/main/java/software/amazon/fms/notificationchannel/ReadHandler.java
+++ b/aws-fms-notificationchannel/src/main/java/software/amazon/fms/notificationchannel/ReadHandler.java
@@ -1,10 +1,19 @@
 package software.amazon.fms.notificationchannel;
 
+import software.amazon.awssdk.services.fms.FmsClient;
 import software.amazon.awssdk.services.fms.model.GetNotificationChannelResponse;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 
 public class ReadHandler extends NotificationChannelHandler {
+
+    ReadHandler() {
+        super();
+    }
+
+    ReadHandler(final FmsClient client) {
+        super(client);
+    }
 
     @Override
     protected boolean throwNotFoundException() {

--- a/aws-fms-notificationchannel/src/main/java/software/amazon/fms/notificationchannel/UpdateHandler.java
+++ b/aws-fms-notificationchannel/src/main/java/software/amazon/fms/notificationchannel/UpdateHandler.java
@@ -1,5 +1,6 @@
 package software.amazon.fms.notificationchannel;
 
+import software.amazon.awssdk.services.fms.FmsClient;
 import software.amazon.awssdk.services.fms.model.GetNotificationChannelResponse;
 import software.amazon.awssdk.services.fms.model.PutNotificationChannelResponse;
 import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
@@ -7,6 +8,14 @@ import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 
 public class UpdateHandler extends NotificationChannelHandler {
+
+    UpdateHandler() {
+        super();
+    }
+
+    UpdateHandler(final FmsClient client) {
+        super(client);
+    }
 
     @Override
     protected boolean throwNotFoundException() {

--- a/aws-fms-notificationchannel/src/test/java/software/amazon/fms/notificationchannel/CreateHandlerTest.java
+++ b/aws-fms-notificationchannel/src/test/java/software/amazon/fms/notificationchannel/CreateHandlerTest.java
@@ -3,6 +3,7 @@ package software.amazon.fms.notificationchannel;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
+import software.amazon.awssdk.services.fms.FmsClient;
 import software.amazon.awssdk.services.fms.model.FmsRequest;
 import software.amazon.awssdk.services.fms.model.GetNotificationChannelRequest;
 import software.amazon.awssdk.services.fms.model.GetNotificationChannelResponse;
@@ -35,6 +36,9 @@ class CreateHandlerTest {
     private AmazonWebServicesClientProxy proxy;
 
     @Mock
+    private FmsClient client;
+
+    @Mock
     private Logger logger;
 
     @Captor
@@ -49,7 +53,7 @@ class CreateHandlerTest {
     void setup() {
         proxy = mock(AmazonWebServicesClientProxy.class);
         logger = mock(Logger.class);
-        handler = new CreateHandler();
+        handler = new CreateHandler(client);
         sampleSnsTopicArn = "arn:aws:sns:us-east-1:012345678901:test-topic";
         sampleSnsRoleName = "arn:aws:iam::012345678901:role/aws-service-role/fms.amazonaws.com/AWSServiceRoleForFMS";
 

--- a/aws-fms-notificationchannel/src/test/java/software/amazon/fms/notificationchannel/DeleteHandlerTest.java
+++ b/aws-fms-notificationchannel/src/test/java/software/amazon/fms/notificationchannel/DeleteHandlerTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.fms.FmsClient;
 import software.amazon.awssdk.services.fms.model.DeleteNotificationChannelRequest;
 import software.amazon.awssdk.services.fms.model.DeleteNotificationChannelResponse;
 import software.amazon.awssdk.services.fms.model.FmsRequest;
@@ -35,6 +36,9 @@ class DeleteHandlerTest {
     private AmazonWebServicesClientProxy proxy;
 
     @Mock
+    private FmsClient client;
+
+    @Mock
     private Logger logger;
 
     @Captor
@@ -49,7 +53,7 @@ class DeleteHandlerTest {
     void setup() {
         proxy = mock(AmazonWebServicesClientProxy.class);
         logger = mock(Logger.class);
-        handler = new DeleteHandler();
+        handler = new DeleteHandler(client);
         sampleSnsTopicArn = "arn:aws:sns:us-east-1:012345678901:test-topic";
         sampleSnsRoleName = "arn:aws:iam::012345678901:role/aws-service-role/fms.amazonaws.com/AWSServiceRoleForFMS";
 

--- a/aws-fms-notificationchannel/src/test/java/software/amazon/fms/notificationchannel/ReadHandlerTest.java
+++ b/aws-fms-notificationchannel/src/test/java/software/amazon/fms/notificationchannel/ReadHandlerTest.java
@@ -3,6 +3,7 @@ package software.amazon.fms.notificationchannel;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
+import software.amazon.awssdk.services.fms.FmsClient;
 import software.amazon.awssdk.services.fms.model.FmsRequest;
 import software.amazon.awssdk.services.fms.model.GetNotificationChannelRequest;
 import software.amazon.awssdk.services.fms.model.GetNotificationChannelResponse;
@@ -36,6 +37,9 @@ class ReadHandlerTest {
     private AmazonWebServicesClientProxy proxy;
 
     @Mock
+    private FmsClient client;
+
+    @Mock
     private Logger logger;
 
     @Captor
@@ -50,7 +54,7 @@ class ReadHandlerTest {
     void setup() {
         proxy = mock(AmazonWebServicesClientProxy.class);
         logger = mock(Logger.class);
-        handler = new ReadHandler();
+        handler = new ReadHandler(client);
         sampleSnsTopicArn = "arn:aws:sns:us-east-1:012345678901:test-topic";
         sampleSnsRoleName = "arn:aws:iam::012345678901:role/aws-service-role/fms.amazonaws.com/AWSServiceRoleForFMS";
 

--- a/aws-fms-notificationchannel/src/test/java/software/amazon/fms/notificationchannel/UpdateHandlerTest.java
+++ b/aws-fms-notificationchannel/src/test/java/software/amazon/fms/notificationchannel/UpdateHandlerTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.fms.FmsClient;
 import software.amazon.awssdk.services.fms.model.FmsRequest;
 import software.amazon.awssdk.services.fms.model.GetNotificationChannelRequest;
 import software.amazon.awssdk.services.fms.model.GetNotificationChannelResponse;
@@ -32,6 +33,9 @@ class UpdateHandlerTest {
     private AmazonWebServicesClientProxy proxy;
 
     @Mock
+    private FmsClient client;
+
+    @Mock
     private Logger logger;
 
     @Captor
@@ -46,7 +50,7 @@ class UpdateHandlerTest {
     void setup() {
         proxy = mock(AmazonWebServicesClientProxy.class);
         logger = mock(Logger.class);
-        handler = new UpdateHandler();
+        handler = new UpdateHandler(client);
         sampleSnsTopicArn = "arn:aws:sns:us-east-1:012345678901:test-topic";
         sampleSnsRoleName = "arn:aws:iam::012345678901:role/aws-service-role/fms.amazonaws.com/AWSServiceRoleForFMS";
 

--- a/aws-fms-policy/src/main/java/software/amazon/fms/policy/CreateHandler.java
+++ b/aws-fms-policy/src/main/java/software/amazon/fms/policy/CreateHandler.java
@@ -1,5 +1,6 @@
 package software.amazon.fms.policy;
 
+import software.amazon.awssdk.services.fms.FmsClient;
 import software.amazon.awssdk.services.fms.model.DeletePolicyRequest;
 import software.amazon.awssdk.services.fms.model.PutPolicyRequest;
 import software.amazon.awssdk.services.fms.model.PutPolicyResponse;
@@ -11,6 +12,14 @@ import software.amazon.fms.policy.helpers.CfnHelper;
 import software.amazon.fms.policy.helpers.FmsHelper;
 
 public class CreateHandler extends PolicyHandler<PutPolicyResponse> {
+
+    CreateHandler() {
+        super();
+    }
+
+    CreateHandler(final FmsClient client) {
+        super(client);
+    }
 
     @Override
     protected PutPolicyResponse makeRequest(

--- a/aws-fms-policy/src/main/java/software/amazon/fms/policy/DeleteHandler.java
+++ b/aws-fms-policy/src/main/java/software/amazon/fms/policy/DeleteHandler.java
@@ -1,5 +1,6 @@
 package software.amazon.fms.policy;
 
+import software.amazon.awssdk.services.fms.FmsClient;
 import software.amazon.awssdk.services.fms.model.DeletePolicyRequest;
 import software.amazon.awssdk.services.fms.model.DeletePolicyResponse;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
@@ -7,6 +8,14 @@ import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 public class DeleteHandler extends PolicyHandler<DeletePolicyResponse> {
+
+    DeleteHandler() {
+        super();
+    }
+
+    DeleteHandler(final FmsClient client) {
+        super(client);
+    }
 
     @Override
     protected DeletePolicyResponse makeRequest(

--- a/aws-fms-policy/src/main/java/software/amazon/fms/policy/PolicyHandler.java
+++ b/aws-fms-policy/src/main/java/software/amazon/fms/policy/PolicyHandler.java
@@ -19,10 +19,19 @@ abstract class PolicyHandler<ResponseT extends FmsResponse> extends BaseHandler<
     /** FMS client instance to make requests on behalf of CloudFormation. */
     protected final FmsClient client;
 
-    /** Constructor. */
+    /** Constructor for use by CloudFormation, uses default FMS client. */
     PolicyHandler() {
 
         client = FmsClient.create();
+    }
+
+    /**
+     * Constructor for use in tests, allows for a mocked client.
+     * @param client The FmsClient to use.
+     */
+    PolicyHandler(final FmsClient client) {
+
+        this.client = client;
     }
 
     /**

--- a/aws-fms-policy/src/main/java/software/amazon/fms/policy/ReadHandler.java
+++ b/aws-fms-policy/src/main/java/software/amazon/fms/policy/ReadHandler.java
@@ -1,5 +1,6 @@
 package software.amazon.fms.policy;
 
+import software.amazon.awssdk.services.fms.FmsClient;
 import software.amazon.awssdk.services.fms.model.GetPolicyRequest;
 import software.amazon.awssdk.services.fms.model.GetPolicyResponse;
 import software.amazon.awssdk.services.fms.model.ListTagsForResourceRequest;
@@ -10,6 +11,14 @@ import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.fms.policy.helpers.CfnHelper;
 
 public class ReadHandler extends PolicyHandler<GetPolicyResponse> {
+
+    ReadHandler() {
+        super();
+    }
+
+    ReadHandler(final FmsClient client) {
+        super(client);
+    }
 
     @Override
     protected GetPolicyResponse makeRequest(

--- a/aws-fms-policy/src/main/java/software/amazon/fms/policy/UpdateHandler.java
+++ b/aws-fms-policy/src/main/java/software/amazon/fms/policy/UpdateHandler.java
@@ -1,5 +1,6 @@
 package software.amazon.fms.policy;
 
+import software.amazon.awssdk.services.fms.FmsClient;
 import software.amazon.awssdk.services.fms.model.GetPolicyRequest;
 import software.amazon.awssdk.services.fms.model.GetPolicyResponse;
 import software.amazon.awssdk.services.fms.model.ListTagsForResourceRequest;
@@ -20,6 +21,14 @@ import software.amazon.fms.policy.helpers.FmsHelper;
 import java.util.List;
 
 public class UpdateHandler extends PolicyHandler<PutPolicyResponse> {
+
+    UpdateHandler() {
+        super();
+    }
+
+    UpdateHandler(final FmsClient client) {
+        super(client);
+    }
 
     @Override
     protected PutPolicyResponse makeRequest(

--- a/aws-fms-policy/src/test/java/software/amazon/fms/policy/CreateHandlerTest.java
+++ b/aws-fms-policy/src/test/java/software/amazon/fms/policy/CreateHandlerTest.java
@@ -5,6 +5,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
 import org.mockito.Mockito;
+import software.amazon.awssdk.services.fms.FmsClient;
 import software.amazon.awssdk.services.fms.model.DeletePolicyRequest;
 import software.amazon.awssdk.services.fms.model.DeletePolicyResponse;
 import software.amazon.awssdk.services.fms.model.FmsRequest;
@@ -51,6 +52,9 @@ class CreateHandlerTest {
     private AmazonWebServicesClientProxy proxy;
 
     @Mock
+    private FmsClient client;
+
+    @Mock
     private Logger logger;
 
     @Captor
@@ -66,7 +70,7 @@ class CreateHandlerTest {
         proxy = mock(AmazonWebServicesClientProxy.class);
         logger = mock(Logger.class);
         configuration = new Configuration();
-        handler = new CreateHandler();
+        handler = new CreateHandler(client);
     }
 
     @Test

--- a/aws-fms-policy/src/test/java/software/amazon/fms/policy/DeleteHandlerTest.java
+++ b/aws-fms-policy/src/test/java/software/amazon/fms/policy/DeleteHandlerTest.java
@@ -3,6 +3,7 @@ package software.amazon.fms.policy;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
+import software.amazon.awssdk.services.fms.FmsClient;
 import software.amazon.awssdk.services.fms.model.DeletePolicyRequest;
 import software.amazon.awssdk.services.fms.model.DeletePolicyResponse;
 import software.amazon.awssdk.services.fms.model.FmsRequest;
@@ -37,6 +38,9 @@ class DeleteHandlerTest {
     private AmazonWebServicesClientProxy proxy;
 
     @Mock
+    private FmsClient client;
+
+    @Mock
     private Logger logger;
 
     @Captor
@@ -49,7 +53,7 @@ class DeleteHandlerTest {
 
         proxy = mock(AmazonWebServicesClientProxy.class);
         logger = mock(Logger.class);
-        handler = new DeleteHandler();
+        handler = new DeleteHandler(client);
     }
 
     @Test

--- a/aws-fms-policy/src/test/java/software/amazon/fms/policy/ReadHandlerTest.java
+++ b/aws-fms-policy/src/test/java/software/amazon/fms/policy/ReadHandlerTest.java
@@ -3,6 +3,7 @@ package software.amazon.fms.policy;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
+import software.amazon.awssdk.services.fms.FmsClient;
 import software.amazon.awssdk.services.fms.model.FmsRequest;
 import software.amazon.awssdk.services.fms.model.GetPolicyRequest;
 import software.amazon.awssdk.services.fms.model.GetPolicyResponse;
@@ -42,6 +43,9 @@ class ReadHandlerTest {
     private AmazonWebServicesClientProxy proxy;
 
     @Mock
+    private FmsClient client;
+
+    @Mock
     private Logger logger;
 
     @Captor
@@ -54,7 +58,7 @@ class ReadHandlerTest {
 
         proxy = mock(AmazonWebServicesClientProxy.class);
         logger = mock(Logger.class);
-        handler = new ReadHandler();
+        handler = new ReadHandler(client);
     }
 
     @Test

--- a/aws-fms-policy/src/test/java/software/amazon/fms/policy/UpdateHandlerTest.java
+++ b/aws-fms-policy/src/test/java/software/amazon/fms/policy/UpdateHandlerTest.java
@@ -3,6 +3,7 @@ package software.amazon.fms.policy;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
+import software.amazon.awssdk.services.fms.FmsClient;
 import software.amazon.awssdk.services.fms.model.FmsRequest;
 import software.amazon.awssdk.services.fms.model.GetPolicyRequest;
 import software.amazon.awssdk.services.fms.model.GetPolicyResponse;
@@ -53,6 +54,9 @@ class UpdateHandlerTest {
     private AmazonWebServicesClientProxy proxy;
 
     @Mock
+    private FmsClient client;
+
+    @Mock
     private Logger logger;
 
     @Captor
@@ -68,7 +72,7 @@ class UpdateHandlerTest {
         proxy = mock(AmazonWebServicesClientProxy.class);
         logger = mock(Logger.class);
         configuration = new Configuration();
-        handler = new UpdateHandler();
+        handler = new UpdateHandler(client);
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added new constructors to handlers to allow unit tests to mock the FMS client.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
