### PR TITLE
Support third-party firewall and centralized Amazon network firewall

### DIFF
--- a/aws-fms-policy/aws-fms-policy.json
+++ b/aws-fms-policy/aws-fms-policy.json
@@ -92,6 +92,14 @@
             "pattern": "^([^\\s]*)$",
             "minLength": 1,
             "maxLength": 1024
+        },
+        "FirewallDeploymentModel": {
+            "description": "Firewall deployment mode.",
+            "type": "string",
+            "enum": [
+                "DISTRIBUTED",
+                "CENTRALIZED"
+            ]
         }
     },
     "properties": {
@@ -143,7 +151,7 @@
                 "ManagedServiceData": {
                     "type": "string",
                     "minLength": 1,
-                    "maxLength": 4096
+                    "maxLength": 8192
                 },
                 "Type": {
                     "type": "string",
@@ -155,8 +163,51 @@
                         "SECURITY_GROUPS_CONTENT_AUDIT",
                         "SECURITY_GROUPS_USAGE_AUDIT",
                         "NETWORK_FIREWALL",
+                        "THIRD_PARTY_FIREWALL",
                         "DNS_FIREWALL"
                     ]
+                },
+                "PolicyOption": {
+                  "type": "object",
+                  "properties": {
+                    "NetworkFirewallPolicy": {
+                      "type": "object",
+                      "properties": {
+                        "FirewallDeploymentModel": {
+                          "$ref": "#/definitions/FirewallDeploymentModel"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "FirewallDeploymentModel"
+                      ]
+                    },
+                    "ThirdPartyFirewallPolicy": {
+                      "type": "object",
+                      "properties": {
+                        "FirewallDeploymentModel": {
+                          "$ref": "#/definitions/FirewallDeploymentModel"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "FirewallDeploymentModel"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false,
+                  "oneOf": [
+                    {
+                      "required": [
+                        "NetworkFirewallPolicy"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "ThirdPartyFirewallPolicy"
+                      ]
+                    }
+                  ]
                 }
             },
             "additionalProperties": false,
@@ -208,8 +259,12 @@
                 "wafv2:CheckCapacity",
                 "wafv2:ListRuleGroups",
                 "wafv2:ListAvailableManagedRuleGroups",
+                "wafv2:ListAvailableManagedRuleGroupVersions",
                 "network-firewall:DescribeRuleGroup",
-                "route53resolver:ListFirewallRuleGroups"
+                "route53resolver:ListFirewallRuleGroups",
+                "ec2:DescribeAvailabilityZones",
+                "s3:PutBucketPolicy",
+                "s3:GetBucketPolicy"
             ]
         },
         "update": {
@@ -223,8 +278,12 @@
                 "wafv2:CheckCapacity",
                 "wafv2:ListRuleGroups",
                 "wafv2:ListAvailableManagedRuleGroups",
+                "wafv2:ListAvailableManagedRuleGroupVersions",
                 "network-firewall:DescribeRuleGroup",
-                "route53resolver:ListFirewallRuleGroups"
+                "route53resolver:ListFirewallRuleGroups",
+                "ec2:DescribeAvailabilityZones",
+                "s3:PutBucketPolicy",
+                "s3:GetBucketPolicy"
             ]
         },
         "read": {

--- a/aws-fms-policy/pom.xml
+++ b/aws-fms-policy/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>fms</artifactId>
-            <version>2.17.38</version>
+            <version>2.17.161</version>
         </dependency>
     </dependencies>
 
@@ -82,12 +82,12 @@
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>sdk-core</artifactId>
-                <version>2.17.38</version>
+                <version>2.17.161</version>
             </dependency>
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>utils</artifactId>
-                <version>2.17.38</version>
+                <version>2.17.161</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/aws-fms-policy/resource-role.yaml
+++ b/aws-fms-policy/resource-role.yaml
@@ -23,6 +23,7 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
+                - "ec2:DescribeAvailabilityZones"
                 - "fms:DeletePolicy"
                 - "fms:GetPolicy"
                 - "fms:ListPolicies"
@@ -32,8 +33,11 @@ Resources:
                 - "fms:UntagResource"
                 - "network-firewall:DescribeRuleGroup"
                 - "route53resolver:ListFirewallRuleGroups"
+                - "s3:GetBucketPolicy"
+                - "s3:PutBucketPolicy"
                 - "waf-regional:ListRuleGroups"
                 - "wafv2:CheckCapacity"
+                - "wafv2:ListAvailableManagedRuleGroupVersions"
                 - "wafv2:ListAvailableManagedRuleGroups"
                 - "wafv2:ListRuleGroups"
                 Resource: "*"

--- a/aws-fms-policy/src/main/java/software/amazon/fms/policy/helpers/CfnHelper.java
+++ b/aws-fms-policy/src/main/java/software/amazon/fms/policy/helpers/CfnHelper.java
@@ -2,12 +2,16 @@ package software.amazon.fms.policy.helpers;
 
 import org.apache.commons.collections.CollectionUtils;
 import software.amazon.awssdk.services.fms.model.CustomerPolicyScopeIdType;
+import software.amazon.awssdk.services.fms.model.Policy;
 import software.amazon.awssdk.services.fms.model.Tag;
 import software.amazon.fms.policy.IEMap;
+import software.amazon.fms.policy.NetworkFirewallPolicy;
+import software.amazon.fms.policy.PolicyOption;
 import software.amazon.fms.policy.PolicyTag;
 import software.amazon.fms.policy.ResourceModel;
 import software.amazon.fms.policy.ResourceTag;
 import software.amazon.fms.policy.SecurityServicePolicyData;
+import software.amazon.fms.policy.ThirdPartyFirewallPolicy;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,6 +34,12 @@ public class CfnHelper {
         // add the managed service data if it exists
         if (!policy.securityServicePolicyData().managedServiceData().isEmpty()) {
             securityServicePolicyData.managedServiceData(policy.securityServicePolicyData().managedServiceData());
+        }
+
+        if (policy.securityServicePolicyData().policyOption() != null) {
+            securityServicePolicyData.policyOption(convertFmsPolicyOptionToCFNPolicyOption(
+                policy.securityServicePolicyData().policyOption()
+            ));
         }
 
         // assemble the resource model with the required parameters
@@ -113,5 +123,29 @@ public class CfnHelper {
         // build and return the resource model
         return resourceModelBuilder.build();
 
+    }
+
+    /**
+     * Convert the FMS PolicyOption to CFN PolicyOption.
+     * @param policyOption FMS PolicyOption.
+     * @return CFN resource model that was converted to.
+     */
+    public static PolicyOption convertFmsPolicyOptionToCFNPolicyOption(
+        software.amazon.awssdk.services.fms.model.PolicyOption policyOption) {
+
+        final PolicyOption.PolicyOptionBuilder builder = PolicyOption.builder();
+
+        if (policyOption.networkFirewallPolicy() != null) {
+            builder.networkFirewallPolicy(NetworkFirewallPolicy.
+                builder().firewallDeploymentModel(policyOption.
+                    networkFirewallPolicy().firewallDeploymentModelAsString()).build()).build();
+        }
+
+        if (policyOption.thirdPartyFirewallPolicy() != null) {
+             builder.thirdPartyFirewallPolicy(ThirdPartyFirewallPolicy.
+                builder().firewallDeploymentModel(policyOption.
+                    thirdPartyFirewallPolicy().firewallDeploymentModelAsString()).build()).build();
+        }
+        return builder.build();
     }
 }

--- a/aws-fms-policy/src/main/java/software/amazon/fms/policy/helpers/FmsHelper.java
+++ b/aws-fms-policy/src/main/java/software/amazon/fms/policy/helpers/FmsHelper.java
@@ -15,6 +15,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import software.amazon.awssdk.services.fms.model.PolicyOption;
+import software.amazon.awssdk.services.fms.model.NetworkFirewallPolicy;
+import software.amazon.awssdk.services.fms.model.ThirdPartyFirewallPolicy;
+
 
 public class FmsHelper {
 
@@ -34,6 +38,30 @@ public class FmsHelper {
         return fmsIEMap;
     }
 
+     /**
+     * Helper method to convert the cfn input PolicyOption to FMS PolicyOption.
+     * @param policyOption CFN input PolicyOption,
+     * @return The converted PolicyOption.
+     */
+     static PolicyOption convertCFNPolicyOptionToFMSPolicyOption(software.amazon.fms.policy.PolicyOption policyOption) {
+
+         final PolicyOption.Builder builder = PolicyOption.builder();
+
+         if (policyOption.getNetworkFirewallPolicy() != null) {
+             builder.networkFirewallPolicy(NetworkFirewallPolicy.builder()
+                 .firewallDeploymentModel(
+                     policyOption.getNetworkFirewallPolicy().getFirewallDeploymentModel()
+                 ).build()).build();
+         }
+         if (policyOption.getThirdPartyFirewallPolicy() != null) {
+             builder.thirdPartyFirewallPolicy(ThirdPartyFirewallPolicy.builder()
+                 .firewallDeploymentModel(
+                     policyOption.getThirdPartyFirewallPolicy().getFirewallDeploymentModel()
+                 ).build()).build();
+         }
+         return builder.build();
+     }
+
     /**
      * Logic for converting a CFN resource model (from the resource provider) to an FMS policy (from the FMS SDK).
      * @param resourceModel CFN resource model that was converted from.
@@ -48,6 +76,11 @@ public class FmsHelper {
         // add the managed service data if it exists
         if (resourceModel.getSecurityServicePolicyData().getManagedServiceData() != null) {
                 securityServicePolicyData.managedServiceData(resourceModel.getSecurityServicePolicyData().getManagedServiceData());
+        }
+
+        if (resourceModel.getSecurityServicePolicyData().getPolicyOption() != null) {
+            securityServicePolicyData.policyOption(convertCFNPolicyOptionToFMSPolicyOption(
+                resourceModel.getSecurityServicePolicyData().getPolicyOption()));
         }
 
         // assemble the policy with the required parameters

--- a/aws-fms-policy/src/test/java/software/amazon/fms/policy/helpers/CfnSampleHelper.java
+++ b/aws-fms-policy/src/test/java/software/amazon/fms/policy/helpers/CfnSampleHelper.java
@@ -6,6 +6,9 @@ import software.amazon.fms.policy.PolicyTag;
 import software.amazon.fms.policy.ResourceModel;
 import software.amazon.fms.policy.ResourceTag;
 import software.amazon.fms.policy.SecurityServicePolicyData;
+import software.amazon.fms.policy.PolicyOption;
+import software.amazon.fms.policy.NetworkFirewallPolicy;
+
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -25,11 +28,15 @@ public class CfnSampleHelper extends BaseSampleHelper {
             final boolean includeTag1,
             final boolean includeTag2) {
 
+
+        PolicyOption p = PolicyOption.builder()
+                .networkFirewallPolicy(NetworkFirewallPolicy.builder()
+                .firewallDeploymentModel("CENTRALIZED").build()).build();
+
         // assemble sample security service policy data
         final SecurityServicePolicyData securityServicePolicyData = SecurityServicePolicyData.builder()
                 .managedServiceData(sampleManagedServiceData)
-                .type(samplePolicyType)
-                .build();
+                .type(samplePolicyType).policyOption(p).build();
 
         // assemble a sample resource model with only the required parameters
         final ResourceModel.ResourceModelBuilder resourceModelBuilder = ResourceModel.builder()

--- a/aws-fms-policy/src/test/java/software/amazon/fms/policy/helpers/FmsSampleHelper.java
+++ b/aws-fms-policy/src/test/java/software/amazon/fms/policy/helpers/FmsSampleHelper.java
@@ -25,6 +25,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import software.amazon.awssdk.services.fms.model.PolicyOption;
+import software.amazon.awssdk.services.fms.model.NetworkFirewallPolicy;
 
 public class FmsSampleHelper extends BaseSampleHelper {
 
@@ -37,9 +39,12 @@ public class FmsSampleHelper extends BaseSampleHelper {
 
         // assemble sample security service policy data
         final SecurityServicePolicyData sampleSecurityServicePolicyData = SecurityServicePolicyData.builder()
-                .managedServiceData(sampleManagedServiceData)
-                .type(samplePolicyType)
-                .build();
+            .managedServiceData(sampleManagedServiceData)
+            .type(samplePolicyType)
+            .policyOption(PolicyOption.builder()
+                .networkFirewallPolicy(NetworkFirewallPolicy.builder()
+                    .firewallDeploymentModel("CENTRALIZED").build()).build())
+            .build();
         // assemble a sample policy with only the required parameters
         final Policy.Builder policyBuilder = Policy.builder()
                 .excludeResourceTags(sampleExcludeResourceTags)


### PR DESCRIPTION

*Description of changes:*

AWS Firewall Manager Service support the third-party network firewall and centralized deployment mode of AWS network firewall.
