### PR TITLE
fix the out-of-band tagging test

### DIFF
--- a/aws-fms-resourceset/aws-fms-resourceset.json
+++ b/aws-fms-resourceset/aws-fms-resourceset.json
@@ -52,7 +52,11 @@
         "tagOnCreate": true,
         "tagUpdatable": true,
         "cloudFormationSystemTags": true,
-        "tagProperty": "/properties/Tags"
+        "tagProperty": "/properties/Tags",
+        "permissions": [
+            "fms:TagResource",
+            "fms:UntagResource"
+        ]
     },
     "properties": {
         "Id": {

--- a/aws-fms-resourceset/src/main/java/software/amazon/fms/resourceset/UpdateHandler.java
+++ b/aws-fms-resourceset/src/main/java/software/amazon/fms/resourceset/UpdateHandler.java
@@ -23,6 +23,7 @@ import software.amazon.fms.resourceset.helpers.CfnHelper;
 import software.amazon.fms.resourceset.helpers.FmsHelper;
 
 import java.util.List;
+import java.util.Map;
 
 public class UpdateHandler extends ResourceSetHandler<PutResourceSetResponse> {
 
@@ -69,23 +70,14 @@ public class UpdateHandler extends ResourceSetHandler<PutResourceSetResponse> {
         logger.log("ResourceSet updated successfully");
         logRequest(putResourceSetResponse, logger);
 
-        // make a list request to get the current tags on the ResourceSet
-        logger.log("Retrieving ResourceSet tags");
-        final ListTagsForResourceRequest listTagsForResourceRequest = ListTagsForResourceRequest.builder()
-                .resourceArn(getResourceSetResponse.resourceSetArn())
-                .build();
-        final ListTagsForResourceResponse listTagsForResourceResponse = proxy.injectCredentialsAndInvokeV2(
-                listTagsForResourceRequest,
-                client::listTagsForResource);
-        logger.log("ResourceSet tags retrieved successfully");
-        logRequest(listTagsForResourceResponse, logger);
+        Map<String, String> previousResourceTags = request.getPreviousResourceTags();
 
         // determine tags to remove and add
         final List<String> removeTags = FmsHelper.tagsToRemove(
-                listTagsForResourceResponse.tagList(),
+                previousResourceTags,
                 request.getDesiredResourceTags());
         final List<Tag> addTags = FmsHelper.tagsToAdd(
-                listTagsForResourceResponse.tagList(),
+                previousResourceTags,
                 request.getDesiredResourceTags());
 
         // make an untag request

--- a/aws-fms-resourceset/src/main/java/software/amazon/fms/resourceset/helpers/FmsHelper.java
+++ b/aws-fms-resourceset/src/main/java/software/amazon/fms/resourceset/helpers/FmsHelper.java
@@ -82,13 +82,14 @@ public class FmsHelper {
      * @param desiredTagList The tags that should exist on the policy.
      * @return A list of tag keys to remove from the policy.
      */
-    public static List<String> tagsToRemove(List<Tag> existingTagList, Map<String, String> desiredTagList) {
+    public static List<String> tagsToRemove(Map<String, String> existingTagList, Map<String, String> desiredTagList) {
 
         // format existing and new tags
+        final List<Tag> previousTagListFms = convertCFNTagMapToFMSTagSet(existingTagList);
         final List<Tag> desiredTagListFms = convertCFNTagMapToFMSTagSet(desiredTagList);
 
         // determine tags to remove
-        return existingTagList.stream()
+        return previousTagListFms.stream()
                 .filter(tag -> !desiredTagListFms.contains(tag))
                 .map(Tag::key)
                 .collect(Collectors.toList());
@@ -100,14 +101,15 @@ public class FmsHelper {
      * @param desiredTagList The tags that should exist on the policy.
      * @return A list of tags to add to the policy.
      */
-    public static List<Tag> tagsToAdd(List<Tag> existingTagList, Map<String, String> desiredTagList) {
+    public static List<Tag> tagsToAdd(Map<String, String> existingTagList, Map<String, String> desiredTagList) {
 
         // format existing and new tags
+        final List<Tag> previousTagListFms = convertCFNTagMapToFMSTagSet(existingTagList);
         final List<Tag> desiredTagListFms = convertCFNTagMapToFMSTagSet(desiredTagList);
 
         // determine tags to add
         return desiredTagListFms.stream()
-                .filter(tag -> !existingTagList.contains(tag))
+                .filter(tag -> !previousTagListFms.contains(tag))
                 .collect(Collectors.toList());
     }
 }

--- a/aws-fms-resourceset/src/test/java/software/amazon/fms/resourceset/UpdateHandlerTest.java
+++ b/aws-fms-resourceset/src/test/java/software/amazon/fms/resourceset/UpdateHandlerTest.java
@@ -99,16 +99,6 @@ public class UpdateHandlerTest {
                         ArgumentMatchers.any()
                 );
 
-        // stub the response for the list tags request
-        final ListTagsForResourceResponse describeListResponse =
-                FmsSampleHelper.sampleListTagsForResourceResponse(false, false);
-        doReturn(describeListResponse)
-                .when(proxy)
-                .injectCredentialsAndInvokeV2(
-                        ArgumentMatchers.isA(ListTagsForResourceRequest.class),
-                        ArgumentMatchers.any()
-                );
-
         // stub the response for the list resourceSet resources request
         final ListResourceSetResourcesResponse describeListResourceSetResourcesResponse =
                 FmsSampleHelper.sampleListResourceSetResourcesResponseEmptyResource();
@@ -130,14 +120,13 @@ public class UpdateHandlerTest {
                 handler.handleRequest(proxy, request, null, logger);
 
         // verify stub calls
-        verify(proxy, times(4)).injectCredentialsAndInvokeV2(
+        verify(proxy, times(3)).injectCredentialsAndInvokeV2(
                 captor.capture(),
                 ArgumentMatchers.any()
         );
         assertThat(captor.getAllValues()).isEqualTo(Arrays.asList(
                 FmsSampleHelper.sampleGetResourceSetRequest(),
                 FmsSampleHelper.samplePutResourceSetRequiredParametersRequest(true, false, false),
-                FmsSampleHelper.sampleListTagsForResourceRequest(),
                 FmsSampleHelper.sampleListResourceSetResourcesRequest()
         ));
 
@@ -173,16 +162,6 @@ public class UpdateHandlerTest {
                         ArgumentMatchers.any()
                 );
 
-        // stub the response for the list tags request
-        final ListTagsForResourceResponse describeListResponse =
-                FmsSampleHelper.sampleListTagsForResourceResponse(false, false);
-        doReturn(describeListResponse)
-                .when(proxy)
-                .injectCredentialsAndInvokeV2(
-                        ArgumentMatchers.isA(ListTagsForResourceRequest.class),
-                        ArgumentMatchers.any()
-                );
-
         // stub the response for the list resourceSet resources request
         final ListResourceSetResourcesResponse describeListResourceSetResourcesResponse =
                 FmsSampleHelper.sampleListResourceSetResourcesResponseEmptyResource();
@@ -215,14 +194,13 @@ public class UpdateHandlerTest {
                 handler.handleRequest(proxy, request, null, logger);
 
         // verify stub calls
-        verify(proxy, times(5)).injectCredentialsAndInvokeV2(
+        verify(proxy, times(4)).injectCredentialsAndInvokeV2(
                 captor.capture(),
                 ArgumentMatchers.any()
         );
         assertThat(captor.getAllValues()).isEqualTo(Arrays.asList(
                 FmsSampleHelper.sampleGetResourceSetRequest(),
                 FmsSampleHelper.samplePutResourceSetAllParametersRequest(true),
-                FmsSampleHelper.sampleListTagsForResourceRequest(),
                 FmsSampleHelper.sampleListResourceSetResourcesRequest(),
                 FmsSampleHelper.sampleBatchAssociateResourceRequest()
         ));
@@ -260,16 +238,6 @@ public class UpdateHandlerTest {
                         ArgumentMatchers.any()
                 );
 
-        // stub the response for the list tags request
-        final ListTagsForResourceResponse describeListResponse =
-                FmsSampleHelper.sampleListTagsForResourceResponse(false, false);
-        doReturn(describeListResponse)
-                .when(proxy)
-                .injectCredentialsAndInvokeV2(
-                        ArgumentMatchers.isA(ListTagsForResourceRequest.class),
-                        ArgumentMatchers.any()
-                );
-
         // stub the response for the list resourceSet resources request
         final ListResourceSetResourcesResponse describeListResourceSetResourcesResponse =
                 FmsSampleHelper.sampleListResourceSetResourcesResponseMultipleResources();
@@ -302,14 +270,13 @@ public class UpdateHandlerTest {
                 handler.handleRequest(proxy, request, null, logger);
 
         // verify stub calls
-        verify(proxy, times(5)).injectCredentialsAndInvokeV2(
+        verify(proxy, times(4)).injectCredentialsAndInvokeV2(
                 captor.capture(),
                 ArgumentMatchers.any()
         );
         assertThat(captor.getAllValues()).isEqualTo(Arrays.asList(
                 FmsSampleHelper.sampleGetResourceSetRequest(),
                 FmsSampleHelper.samplePutResourceSetAllParametersRequest(true),
-                FmsSampleHelper.sampleListTagsForResourceRequest(),
                 FmsSampleHelper.sampleListResourceSetResourcesRequest(),
                 FmsSampleHelper.sampleBatchDisassociateResourceRequest()
         ));
@@ -345,16 +312,6 @@ public class UpdateHandlerTest {
                         ArgumentMatchers.any()
                 );
 
-        // stub the response for the list tags request
-        final ListTagsForResourceResponse describeListResponse =
-                FmsSampleHelper.sampleListTagsForResourceResponse(true, false);
-        doReturn(describeListResponse)
-                .when(proxy)
-                .injectCredentialsAndInvokeV2(
-                        ArgumentMatchers.isA(ListTagsForResourceRequest.class),
-                        ArgumentMatchers.any()
-                );
-
         // stub the response for the list resourceSet resources request
         final ListResourceSetResourcesResponse describeListResourceSetResourcesResponse =
                 FmsSampleHelper.sampleListResourceSetResourcesResponseEmptyResource();
@@ -376,23 +333,25 @@ public class UpdateHandlerTest {
 
         // model the pre-request and post-request resource state
         final ResourceModel requestExpectedModel = CfnSampleHelper.sampleRequiredParametersResourceModel(true, false, false, false);
+        final ResourceModel previousModel = CfnSampleHelper.sampleRequiredParametersResourceModel(true, false, true, false);
 
         // create the update request and send it
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                 .desiredResourceState(requestExpectedModel)
+                .previousResourceState(previousModel)
+                .previousResourceTags(FmsSampleHelper.generateSampleResourceTags(true, false))
                 .build();
         final ProgressEvent<ResourceModel, CallbackContext> response =
                 handler.handleRequest(proxy, request, null, logger);
 
         // verify stub calls
-        verify(proxy, times(5)).injectCredentialsAndInvokeV2(
+        verify(proxy, times(4)).injectCredentialsAndInvokeV2(
                 captor.capture(),
                 ArgumentMatchers.any()
         );
         assertThat(captor.getAllValues()).isEqualTo(Arrays.asList(
                 FmsSampleHelper.sampleGetResourceSetRequest(),
                 FmsSampleHelper.samplePutResourceSetRequiredParametersRequest(true, false, false),
-                FmsSampleHelper.sampleListTagsForResourceRequest(),
                 FmsSampleHelper.sampleUntagResourceRequest(true, false),
                 FmsSampleHelper.sampleListResourceSetResourcesRequest()
         ));
@@ -424,16 +383,6 @@ public class UpdateHandlerTest {
                 .when(proxy)
                 .injectCredentialsAndInvokeV2(
                         ArgumentMatchers.isA(PutResourceSetRequest.class),
-                        ArgumentMatchers.any()
-                );
-
-        // stub the response for the list tags request
-        final ListTagsForResourceResponse describeListResponse =
-                FmsSampleHelper.sampleListTagsForResourceResponse(false, false);
-        doReturn(describeListResponse)
-                .when(proxy)
-                .injectCredentialsAndInvokeV2(
-                        ArgumentMatchers.isA(ListTagsForResourceRequest.class),
                         ArgumentMatchers.any()
                 );
 
@@ -471,14 +420,13 @@ public class UpdateHandlerTest {
                 handler.handleRequest(proxy, request, null, logger);
 
         // verify stub calls
-        verify(proxy, times(5)).injectCredentialsAndInvokeV2(
+        verify(proxy, times(4)).injectCredentialsAndInvokeV2(
                 captor.capture(),
                 ArgumentMatchers.any()
         );
         assertThat(captor.getAllValues()).isEqualTo(Arrays.asList(
                 FmsSampleHelper.sampleGetResourceSetRequest(),
                 FmsSampleHelper.samplePutResourceSetRequiredParametersRequest(true, false, false),
-                FmsSampleHelper.sampleListTagsForResourceRequest(),
                 FmsSampleHelper.sampleTagResourceRequest(true, false),
                 FmsSampleHelper.sampleListResourceSetResourcesRequest()
         ));
@@ -514,16 +462,6 @@ public class UpdateHandlerTest {
                         ArgumentMatchers.any()
                 );
 
-        // stub the response for the list tags request
-        final ListTagsForResourceResponse describeListResponse =
-                FmsSampleHelper.sampleListTagsForResourceResponse(true, false);
-        doReturn(describeListResponse)
-                .when(proxy)
-                .injectCredentialsAndInvokeV2(
-                        ArgumentMatchers.isA(ListTagsForResourceRequest.class),
-                        ArgumentMatchers.any()
-                );
-
         // stub the response for the untag resource request
         final UntagResourceResponse describeUntagResponse = FmsSampleHelper.sampleUntagResourceResponse();
         doReturn(describeUntagResponse)
@@ -554,6 +492,7 @@ public class UpdateHandlerTest {
 
         // model the pre-request and post-request resource state
         final ResourceModel requestExpectedModel = CfnSampleHelper.sampleRequiredParametersResourceModel(true, false, false, true);
+        final ResourceModel previousModel = CfnSampleHelper.sampleRequiredParametersResourceModel(true, false, true, false);
 
         // create sample tags how cfn interprets them from the resource model
         final Map<String, String> tags = configuration.resourceDefinedTags(requestExpectedModel);
@@ -562,19 +501,20 @@ public class UpdateHandlerTest {
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                 .desiredResourceState(requestExpectedModel)
                 .desiredResourceTags(tags)
+                .previousResourceState(previousModel)
+                .previousResourceTags(FmsSampleHelper.generateSampleResourceTags(true, false))
                 .build();
         final ProgressEvent<ResourceModel, CallbackContext> response =
                 handler.handleRequest(proxy, request, null, logger);
 
         // verify stub calls
-        verify(proxy, times(6)).injectCredentialsAndInvokeV2(
+        verify(proxy, times(5)).injectCredentialsAndInvokeV2(
                 captor.capture(),
                 ArgumentMatchers.any()
         );
         assertThat(captor.getAllValues()).isEqualTo(Arrays.asList(
                 FmsSampleHelper.sampleGetResourceSetRequest(),
                 FmsSampleHelper.samplePutResourceSetRequiredParametersRequest(true, false, false),
-                FmsSampleHelper.sampleListTagsForResourceRequest(),
                 FmsSampleHelper.sampleUntagResourceRequest(true, false),
                 FmsSampleHelper.sampleTagResourceRequest(false, true),
                 FmsSampleHelper.sampleListResourceSetResourcesRequest()

--- a/aws-fms-resourceset/src/test/java/software/amazon/fms/resourceset/helpers/FmsSampleHelper.java
+++ b/aws-fms-resourceset/src/test/java/software/amazon/fms/resourceset/helpers/FmsSampleHelper.java
@@ -11,7 +11,6 @@ import software.amazon.awssdk.services.fms.model.DeleteResourceSetResponse;
 import software.amazon.awssdk.services.fms.model.FailedItem;
 import software.amazon.awssdk.services.fms.model.GetResourceSetResponse;
 import software.amazon.awssdk.services.fms.model.GetResourceSetRequest;
-import software.amazon.awssdk.services.fms.model.GetResourceSetResponse;
 import software.amazon.awssdk.services.fms.model.ListPoliciesResponse;
 import software.amazon.awssdk.services.fms.model.ListResourceSetResourcesRequest;
 import software.amazon.awssdk.services.fms.model.ListResourceSetResourcesResponse;
@@ -20,12 +19,8 @@ import software.amazon.awssdk.services.fms.model.ListTagsForResourceRequest;
 import software.amazon.awssdk.services.fms.model.ListTagsForResourceResponse;
 import software.amazon.awssdk.services.fms.model.PutResourceSetRequest;
 import software.amazon.awssdk.services.fms.model.PutResourceSetResponse;
-import software.amazon.awssdk.services.fms.model.PutResourceSetRequest;
-import software.amazon.awssdk.services.fms.model.PutResourceSetResponse;
-import software.amazon.awssdk.services.fms.model.PutResourceSetResponse;
 import software.amazon.awssdk.services.fms.model.ResourceSetSummary;
 import software.amazon.awssdk.services.fms.model.Resource;
-import software.amazon.awssdk.services.fms.model.ResourceSet;
 import software.amazon.awssdk.services.fms.model.ResourceSet;
 import software.amazon.awssdk.services.fms.model.ResourceTag;
 import software.amazon.awssdk.services.fms.model.Tag;
@@ -36,10 +31,10 @@ import software.amazon.awssdk.services.fms.model.UntagResourceResponse;
 
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class FmsSampleHelper extends BaseSampleHelper {
 
@@ -152,6 +147,25 @@ public class FmsSampleHelper extends BaseSampleHelper {
         }
 
         return ListTagsForResourceResponse.builder().tagList(listTags).build();
+    }
+
+    /***
+     * Assembles a sample tag map in the CloudFormation resource state.
+     * @param includeTag1 Should unique tag 1 be added.
+     * @param includeTag2 Should unique tag 2 be added.
+     * @return The assembled sample tag map.
+     */
+
+    public static Map<String, String> generateSampleResourceTags(final boolean includeTag1, final boolean includeTag2) {
+        // determine tags to include in the map
+        final Map<String, String> tags = new HashMap<>();
+        if (includeTag1) {
+            tags.put(String.format("%s%s", sampleTagKey, "1"), sampleTagValue);
+        }
+        if (includeTag2) {
+            tags.put(String.format("%s%s", sampleTagKey, "2"), sampleTagValue);
+        }
+        return tags;
     }
 
     /**


### PR DESCRIPTION
*Issue #, if available:*
Quick fix on a AWS tagging racing issue

*Description of changes:*
Read the tags from the `ResourceHandlerRequest` instead of explicitly calling the `ListTagsForResource` API to return all the tags

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
